### PR TITLE
Enable TokenSpeed MLA DCP decode

### DIFF
--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -232,7 +232,7 @@ MLA decode backends are selected using the standard
 | `ROCM_AITER_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | %1 | Any | ❌ | ❌ | ❌ | ❌ | ❌ | Decoder | N/A |
 | `ROCM_AITER_MLA_SPARSE` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 1, 64 | Any | ❌ | ❌ | ✅ | ❌ | ❌ | Decoder | N/A |
 | `ROCM_AITER_TRITON_MLA` | fp16, bf16 | `auto` | Any | Any | ❌ | ❌ | ❌ | ❌ | ❌ | Decoder | N/A |
-| `TOKENSPEED_MLA` | fp16, bf16 | `fp8`, `fp8_e4m3` | 32, 64 | Any | ❌ | ❌ | ❌ | ❌ | ❌ | Decoder | 10.x |
+| `TOKENSPEED_MLA` | fp16, bf16 | `fp8`, `fp8_e4m3` | 32, 64 | Any | ❌ | ❌ | ❌ | ❌ | ✅ | Decoder | 10.x |
 | `TRITON_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | %16 | Any | ❌ | ❌ | ❌ | ❌ | ✅ | Decoder | Any |
 | `XPU_MLA_SPARSE` | fp16, bf16 | `auto`, `float16`, `bfloat16` | Any | 576 | ❌ | ❌ | ✅ | ❌ | ❌ | Decoder | Any |
 

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -26,7 +26,7 @@ nvidia-cutlass-dsl[cu13]==4.5.2
 quack-kernels>=0.3.3
 
 # Tokenspeed_MLA for faster mla with spec decode
-tokenspeed-mla==0.1.2; platform_system == "Linux"
+tokenspeed-mla==0.1.8; platform_system == "Linux"
 
 # Humming kernels for quantization gemm
 humming-kernels[cu13]==0.1.10

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -8,6 +8,9 @@ Known Issues:
   test_backend_correctness[small_prefill], but passes when run alone.
 """
 
+import sys
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -32,6 +35,7 @@ from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.fa_utils import flash_attn_supports_mla
 from vllm.v1.attention.backends.mla import flashmla as flashmla_module
+from vllm.v1.attention.backends.mla import tokenspeed_mla as tokenspeed_mla_module
 from vllm.v1.attention.backends.mla.prefill import (
     MLAPrefillBackendEnum,
     get_mla_prefill_backend,
@@ -691,6 +695,84 @@ def test_mock_mla_dcp_fp8_decode_gathers_quantized_query(
         num_heads * impl.dcp_world_size,
         kv_lora_rank + qk_rope_head_dim,
     )
+
+
+def test_tokenspeed_mla_dcp_single_token_decode_contract(monkeypatch):
+    decode_call = None
+
+    def fake_decode(**kwargs):
+        nonlocal decode_call
+        decode_call = kwargs
+        q = kwargs["query"]
+        out = torch.empty(q.shape[0], q.shape[1], q.shape[2], 3, dtype=torch.bfloat16)
+        lse = torch.empty(q.shape[0], q.shape[1], q.shape[2], dtype=torch.float32)
+        return out, lse
+
+    monkeypatch.setitem(
+        sys.modules,
+        "tokenspeed_mla",
+        SimpleNamespace(tokenspeed_mla_decode=fake_decode),
+    )
+
+    impl = object.__new__(tokenspeed_mla_module.TokenspeedMLAImpl)
+    impl.dcp_world_size = 4
+    impl.dcp_rank = 1
+    impl.cp_kv_cache_interleave_size = 1
+    impl.need_to_return_lse_for_decode = True
+    impl.kv_lora_rank = 3
+    impl.qk_rope_head_dim = 2
+    impl.num_heads = 2
+    impl.scale = 1.0
+    impl.softmax_scale = 1.0
+    impl.output_scale = 1.0
+    impl._workspace_buffer = torch.empty(1, dtype=torch.int8)
+
+    metadata = SimpleNamespace(
+        num_decodes=2,
+        num_decode_tokens=8,
+        max_seq_len=128,
+        decode=SimpleNamespace(
+            block_table=torch.arange(8, dtype=torch.int32).view(2, 4),
+            seq_lens=torch.tensor([10, 20], dtype=torch.int32),
+            dcp_tot_seq_lens=torch.tensor([10, 20], dtype=torch.int32),
+        ),
+    )
+    q = torch.empty(8, 2, 5, dtype=torch.float8_e4m3fn)
+    kv_cache = torch.empty(4, 16, 5, dtype=torch.float8_e4m3fn)
+
+    with pytest.raises(NotImplementedError, match="single-token decode"):
+        impl.forward_mqa(
+            q,
+            kv_cache,
+            metadata,
+            SimpleNamespace(_q_scale_float=2.0, _k_scale_float=3.0),
+        )
+
+    metadata.num_decode_tokens = 2
+    metadata.decode.dcp_tot_seq_lens = torch.tensor([33, 44], dtype=torch.int32)
+    q = torch.empty(2, 2, 5, dtype=torch.float8_e4m3fn)
+
+    out, lse = impl.forward_mqa(
+        q,
+        kv_cache,
+        metadata,
+        SimpleNamespace(_q_scale_float=2.0, _k_scale_float=3.0),
+    )
+
+    assert out.shape == (2, 2, 3)
+    assert lse is not None
+    assert lse.shape == (2, 2)
+
+    assert decode_call is not None
+    assert decode_call["query"].shape == (2, 1, 2, 5)
+    torch.testing.assert_close(decode_call["seq_lens"], metadata.decode.seq_lens)
+    torch.testing.assert_close(decode_call["block_tables"], metadata.decode.block_table)
+    torch.testing.assert_close(
+        decode_call["causal_seqs"], metadata.decode.dcp_tot_seq_lens
+    )
+    assert decode_call["return_lse"] is True
+    assert decode_call["cp_world"] == 4
+    assert decode_call["cp_rank"] == 1
 
 
 @pytest.mark.parametrize("is_fp8_kvcache", [False, True], ids=["bf16", "fp8"])

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -699,12 +699,30 @@ def test_mock_mla_dcp_fp8_decode_gathers_quantized_query(
 
 def test_tokenspeed_mla_dcp_single_token_decode_contract(monkeypatch):
     decode_call = None
+    num_decodes = 2
+    tokens_per_decode = 1
+    num_decode_tokens = num_decodes * tokens_per_decode
+    dcp_world_size = 2
+    dcp_rank = 1
+    num_heads = 128
+    kv_lora_rank = 512
+    qk_rope_head_dim = 64
+    head_size = kv_lora_rank + qk_rope_head_dim
+    block_size = 64
+    num_blocks = 4
+    max_seq_len = 24
 
     def fake_decode(**kwargs):
         nonlocal decode_call
         decode_call = kwargs
         q = kwargs["query"]
-        out = torch.empty(q.shape[0], q.shape[1], q.shape[2], 3, dtype=torch.bfloat16)
+        out = torch.empty(
+            q.shape[0],
+            q.shape[1],
+            q.shape[2],
+            kv_lora_rank,
+            dtype=torch.bfloat16,
+        )
         lse = torch.empty(q.shape[0], q.shape[1], q.shape[2], dtype=torch.float32)
         return out, lse
 
@@ -715,42 +733,35 @@ def test_tokenspeed_mla_dcp_single_token_decode_contract(monkeypatch):
     )
 
     impl = object.__new__(tokenspeed_mla_module.TokenspeedMLAImpl)
-    impl.dcp_world_size = 4
-    impl.dcp_rank = 1
+    impl.dcp_world_size = dcp_world_size
+    impl.dcp_rank = dcp_rank
     impl.cp_kv_cache_interleave_size = 1
     impl.need_to_return_lse_for_decode = True
-    impl.kv_lora_rank = 3
-    impl.qk_rope_head_dim = 2
-    impl.num_heads = 2
+    impl.kv_lora_rank = kv_lora_rank
+    impl.qk_rope_head_dim = qk_rope_head_dim
+    impl.num_heads = num_heads
     impl.scale = 1.0
     impl.softmax_scale = 1.0
     impl.output_scale = 1.0
     impl._workspace_buffer = torch.empty(1, dtype=torch.int8)
 
     metadata = SimpleNamespace(
-        num_decodes=2,
-        num_decode_tokens=8,
-        max_seq_len=128,
+        num_decodes=num_decodes,
+        num_decode_tokens=num_decode_tokens,
+        max_seq_len=max_seq_len,
         decode=SimpleNamespace(
-            block_table=torch.arange(8, dtype=torch.int32).view(2, 4),
-            seq_lens=torch.tensor([10, 20], dtype=torch.int32),
-            dcp_tot_seq_lens=torch.tensor([10, 20], dtype=torch.int32),
+            block_table=torch.empty((num_decodes, 1), dtype=torch.int32),
+            seq_lens=torch.tensor([16, max_seq_len], dtype=torch.int32),
+            dcp_tot_seq_lens=torch.tensor([16, max_seq_len], dtype=torch.int32),
         ),
     )
-    q = torch.empty(8, 2, 5, dtype=torch.float8_e4m3fn)
-    kv_cache = torch.empty(4, 16, 5, dtype=torch.float8_e4m3fn)
-
-    with pytest.raises(NotImplementedError, match="single-token decode"):
-        impl.forward_mqa(
-            q,
-            kv_cache,
-            metadata,
-            SimpleNamespace(_q_scale_float=2.0, _k_scale_float=3.0),
-        )
-
-    metadata.num_decode_tokens = 2
-    metadata.decode.dcp_tot_seq_lens = torch.tensor([33, 44], dtype=torch.int32)
-    q = torch.empty(2, 2, 5, dtype=torch.float8_e4m3fn)
+    q = torch.empty(num_decode_tokens, num_heads, head_size, dtype=torch.float8_e4m3fn)
+    kv_cache = torch.empty(
+        num_blocks,
+        block_size,
+        head_size,
+        dtype=torch.float8_e4m3fn,
+    )
 
     out, lse = impl.forward_mqa(
         q,
@@ -759,20 +770,25 @@ def test_tokenspeed_mla_dcp_single_token_decode_contract(monkeypatch):
         SimpleNamespace(_q_scale_float=2.0, _k_scale_float=3.0),
     )
 
-    assert out.shape == (2, 2, 3)
+    assert out.shape == (num_decode_tokens, num_heads, kv_lora_rank)
     assert lse is not None
-    assert lse.shape == (2, 2)
+    assert lse.shape == (num_decode_tokens, num_heads)
 
     assert decode_call is not None
-    assert decode_call["query"].shape == (2, 1, 2, 5)
+    assert decode_call["query"].shape == (
+        num_decodes,
+        tokens_per_decode,
+        num_heads,
+        head_size,
+    )
     torch.testing.assert_close(decode_call["seq_lens"], metadata.decode.seq_lens)
     torch.testing.assert_close(decode_call["block_tables"], metadata.decode.block_table)
     torch.testing.assert_close(
         decode_call["causal_seqs"], metadata.decode.dcp_tot_seq_lens
     )
     assert decode_call["return_lse"] is True
-    assert decode_call["cp_world"] == 4
-    assert decode_call["cp_rank"] == 1
+    assert decode_call["cp_world"] == dcp_world_size
+    assert decode_call["cp_rank"] == dcp_rank
 
 
 @pytest.mark.parametrize("is_fp8_kvcache", [False, True], ids=["bf16", "fp8"])

--- a/vllm/v1/attention/backends/mla/tokenspeed_mla.py
+++ b/vllm/v1/attention/backends/mla/tokenspeed_mla.py
@@ -2,10 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """TokenSpeed CuTe DSL MLA decode backend (Blackwell, FP8 KV cache only)."""
 
+import inspect
 from typing import ClassVar
 
 import torch
 
+from vllm.config import VllmConfig
 from vllm.config.cache import CacheDType
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mla_attention import (
@@ -24,6 +26,7 @@ from vllm.v1.attention.backend import (
     MultipleOf,
 )
 from vllm.v1.attention.backends.utils import KVCacheLayoutType
+from vllm.v1.kv_cache_interface import AttentionSpec
 
 logger = init_logger(__name__)
 
@@ -35,6 +38,8 @@ logger = init_logger(__name__)
 _TOKENSPEED_MAX_Q_LEN = 8
 
 _g_workspace: dict[torch.device, torch.Tensor] = {}
+
+_DCP_DECODE_KWARGS = frozenset({"return_lse", "causal_seqs", "cp_world", "cp_rank"})
 
 
 def _get_workspace(
@@ -51,9 +56,38 @@ def _get_workspace(
     return _g_workspace[device]
 
 
+def _missing_dcp_decode_kwargs() -> set[str]:
+    try:
+        from tokenspeed_mla import tokenspeed_mla_decode
+    except ImportError:
+        return set(_DCP_DECODE_KWARGS)
+
+    try:
+        params = inspect.signature(tokenspeed_mla_decode).parameters
+    except (TypeError, ValueError):
+        return set(_DCP_DECODE_KWARGS)
+    return set(_DCP_DECODE_KWARGS.difference(params))
+
+
 class TokenspeedMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
     query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.UNIFORM
+
+    def __init__(
+        self,
+        kv_cache_spec: "AttentionSpec",
+        layer_names: list[str],
+        vllm_config: "VllmConfig",
+        device: torch.device,
+    ) -> None:
+        super().__init__(
+            kv_cache_spec,
+            layer_names,
+            vllm_config,
+            device,
+            MLACommonMetadata,
+            supports_dcp_with_varlen=True,
+        )
 
 
 class TokenspeedMLABackend(MLACommonBackend):
@@ -111,6 +145,15 @@ class TokenspeedMLABackend(MLACommonBackend):
         from vllm.config import get_current_vllm_config
 
         vllm_config = get_current_vllm_config()
+        if vllm_config.parallel_config.decode_context_parallel_size > 1:
+            missing = _missing_dcp_decode_kwargs()
+            if missing:
+                missing_args = ", ".join(sorted(missing))
+                return (
+                    "tokenspeed_mla_decode does not support DCP decode. "
+                    "Install tokenspeed-mla>=0.1.8; missing arguments: "
+                    f"{missing_args}"
+                )
         if vllm_config.model_config is not None:
             hf_text_config = vllm_config.model_config.hf_text_config
             qk_nope_head_dim = getattr(hf_text_config, "qk_nope_head_dim", 0)
@@ -130,6 +173,11 @@ class TokenspeedMLABackend(MLACommonBackend):
 
 
 class TokenspeedMLAImpl(MLACommonImpl[MLACommonMetadata]):
+    can_return_lse_for_decode: bool = True
+    # tokenspeed_mla_decode returns LSE in log2 units; its own DCP test merges
+    # partial outputs with exp2(lse).
+    lse_base_on_e: bool = False
+
     def __init__(
         self,
         num_heads: int,
@@ -228,17 +276,31 @@ class TokenspeedMLAImpl(MLACommonImpl[MLACommonMetadata]):
             f"q_scale={layer._q_scale_float}, k_scale={layer._k_scale_float}."
         )
 
+        num_decodes = attn_metadata.num_decodes
+        num_decode_tokens = attn_metadata.num_decode_tokens
+        uniform = num_decode_tokens % num_decodes == 0
+        tokens_per_req = num_decode_tokens // num_decodes if uniform else 1
+        block_tables = attn_metadata.decode.block_table
+        seq_lens = attn_metadata.decode.seq_lens
+        causal_seqs = attn_metadata.decode.dcp_tot_seq_lens
+
         # tokenspeed_mla_decode expects query shape
         # (num_decodes, q_len_per_request, num_heads, head_dim).
-        if attn_metadata.num_decode_tokens % attn_metadata.num_decodes != 0:
+        if not uniform:
             logger.warning_once(
                 """TokenspeedMLAImpl got a query of uneven length.
                 This usually indicates an issue in batch reordering
                 or incorrect setup in dummy_run."""
             )
             q = q.unsqueeze(1)
+        elif self.dcp_world_size > 1 and tokens_per_req > 1:
+            raise NotImplementedError(
+                "TokenSpeed MLA DCP only supports single-token decode in this PR. "
+                "Multi-token DCP decode for EAGLE/MTP requires follow-up "
+                "dcp_split_q support."
+            )
         else:
-            q = q.view(attn_metadata.num_decodes, -1, q.shape[-2], q.shape[-1])
+            q = q.view(num_decodes, -1, q.shape[-2], q.shape[-1])
 
         if self.softmax_scale is None:
             # FP8 KV cache is mandatory for this backend, so q_scale/k_scale
@@ -257,22 +319,29 @@ class TokenspeedMLAImpl(MLACommonImpl[MLACommonMetadata]):
 
         # vLLM kv_c_and_k_pe_cache is already (num_blocks, block_size, head_size).
         # tokenspeed_mla_decode wants 3D — pass as-is (no unsqueeze, unlike trtllm).
-        o = tokenspeed_mla_decode(
+        return_lse = self.need_to_return_lse_for_decode
+        kernel_out = tokenspeed_mla_decode(
             query=q,
             kv_cache=kv_c_and_k_pe_cache,
             workspace_buffer=self._workspace_buffer,
             kv_lora_rank=self.kv_lora_rank,
             qk_rope_head_dim=self.qk_rope_head_dim,
-            block_tables=attn_metadata.decode.block_table,
-            seq_lens=attn_metadata.decode.seq_lens,
+            block_tables=block_tables,
+            seq_lens=seq_lens,
             max_seq_len=attn_metadata.max_seq_len,
             softmax_scale=self.softmax_scale,
             output_scale=self.output_scale,
             enable_pdl=False,
+            return_lse=return_lse,
+            causal_seqs=causal_seqs if self.dcp_world_size > 1 else None,
+            cp_world=self.dcp_world_size,
+            cp_rank=self.dcp_rank,
         )
+        if return_lse:
+            o, lse = kernel_out
+            lse = lse.view(-1, lse.shape[-1])
+        else:
+            o, lse = kernel_out, None
 
-        # Flatten the output for consistent shape
         o = o.view(-1, o.shape[-2], o.shape[-1])
-
-        # tokenspeed_mla_decode does not return LSE.
-        return o, None
+        return o, lse

--- a/vllm/v1/attention/backends/mla/tokenspeed_mla.py
+++ b/vllm/v1/attention/backends/mla/tokenspeed_mla.py
@@ -2,12 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """TokenSpeed CuTe DSL MLA decode backend (Blackwell, FP8 KV cache only)."""
 
-import inspect
 from typing import ClassVar
 
 import torch
 
-from vllm.config import VllmConfig
 from vllm.config.cache import CacheDType
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mla_attention import (
@@ -26,7 +24,6 @@ from vllm.v1.attention.backend import (
     MultipleOf,
 )
 from vllm.v1.attention.backends.utils import KVCacheLayoutType
-from vllm.v1.kv_cache_interface import AttentionSpec
 
 logger = init_logger(__name__)
 
@@ -38,8 +35,6 @@ logger = init_logger(__name__)
 _TOKENSPEED_MAX_Q_LEN = 8
 
 _g_workspace: dict[torch.device, torch.Tensor] = {}
-
-_DCP_DECODE_KWARGS = frozenset({"return_lse", "causal_seqs", "cp_world", "cp_rank"})
 
 
 def _get_workspace(
@@ -56,38 +51,9 @@ def _get_workspace(
     return _g_workspace[device]
 
 
-def _missing_dcp_decode_kwargs() -> set[str]:
-    try:
-        from tokenspeed_mla import tokenspeed_mla_decode
-    except ImportError:
-        return set(_DCP_DECODE_KWARGS)
-
-    try:
-        params = inspect.signature(tokenspeed_mla_decode).parameters
-    except (TypeError, ValueError):
-        return set(_DCP_DECODE_KWARGS)
-    return set(_DCP_DECODE_KWARGS.difference(params))
-
-
 class TokenspeedMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
     query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.UNIFORM
-
-    def __init__(
-        self,
-        kv_cache_spec: "AttentionSpec",
-        layer_names: list[str],
-        vllm_config: "VllmConfig",
-        device: torch.device,
-    ) -> None:
-        super().__init__(
-            kv_cache_spec,
-            layer_names,
-            vllm_config,
-            device,
-            MLACommonMetadata,
-            supports_dcp_with_varlen=True,
-        )
 
 
 class TokenspeedMLABackend(MLACommonBackend):
@@ -145,15 +111,6 @@ class TokenspeedMLABackend(MLACommonBackend):
         from vllm.config import get_current_vllm_config
 
         vllm_config = get_current_vllm_config()
-        if vllm_config.parallel_config.decode_context_parallel_size > 1:
-            missing = _missing_dcp_decode_kwargs()
-            if missing:
-                missing_args = ", ".join(sorted(missing))
-                return (
-                    "tokenspeed_mla_decode does not support DCP decode. "
-                    "Install tokenspeed-mla>=0.1.8; missing arguments: "
-                    f"{missing_args}"
-                )
         if vllm_config.model_config is not None:
             hf_text_config = vllm_config.model_config.hf_text_config
             qk_nope_head_dim = getattr(hf_text_config, "qk_nope_head_dim", 0)
@@ -278,26 +235,23 @@ class TokenspeedMLAImpl(MLACommonImpl[MLACommonMetadata]):
 
         num_decodes = attn_metadata.num_decodes
         num_decode_tokens = attn_metadata.num_decode_tokens
-        uniform = num_decode_tokens % num_decodes == 0
-        tokens_per_req = num_decode_tokens // num_decodes if uniform else 1
         block_tables = attn_metadata.decode.block_table
         seq_lens = attn_metadata.decode.seq_lens
         causal_seqs = attn_metadata.decode.dcp_tot_seq_lens
 
         # tokenspeed_mla_decode expects query shape
         # (num_decodes, q_len_per_request, num_heads, head_dim).
-        if not uniform:
+        if num_decode_tokens % num_decodes != 0:
             logger.warning_once(
                 """TokenspeedMLAImpl got a query of uneven length.
                 This usually indicates an issue in batch reordering
                 or incorrect setup in dummy_run."""
             )
             q = q.unsqueeze(1)
-        elif self.dcp_world_size > 1 and tokens_per_req > 1:
+        elif self.dcp_world_size > 1 and num_decode_tokens != num_decodes:
             raise NotImplementedError(
-                "TokenSpeed MLA DCP only supports single-token decode in this PR. "
-                "Multi-token DCP decode for EAGLE/MTP requires follow-up "
-                "dcp_split_q support."
+                "TokenSpeed MLA DCP doesn't support when "
+                "num_decode_tokens != num_decodes."
             )
         else:
             q = q.view(num_decodes, -1, q.shape[-2], q.shape[-1])


### PR DESCRIPTION
## Purpose
Add support for tokenspeed_mla with DCP. 

## Test Plan
1. Test with Kimi-K2.5 + DCP 
2. Test the extended support from tests/v1/attention/test_mla_backends.py


## Test Result
In progress

Follow up PR - Add support for Tokenspeed MLA + DCP + MTP 
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

