### PR TITLE
[Bugfix] Gate DCP prefill and varlen spec decode on CP-aware paths (for vllm-project#48180)

### DIFF
--- a/tests/kernels/attention/test_use_trtllm_attention.py
+++ b/tests/kernels/attention/test_use_trtllm_attention.py
@@ -154,6 +154,17 @@ def test_use_dcp_fallback(_mock):
     assert _call(dcp_world_size=2) is False
 
 
+@patch("vllm.utils.flashinfer.supports_trtllm_attention", return_value=True)
+def test_use_dcp_fallback_prefill(_mock):
+    # TRTLLM prefill has no cross-rank LSE combine for DCP-sharded KV.
+    assert _call(dcp_world_size=2, is_prefill=True) is False
+
+
+@patch("vllm.utils.flashinfer.supports_trtllm_attention", return_value=True)
+def test_use_dcp_fallback_prefill_force_on_still_false(_mock):
+    assert _call(dcp_world_size=2, is_prefill=True, force_use_trtllm=True) is False
+
+
 @patch("vllm.utils.flashinfer.supports_trtllm_attention", return_value=False)
 def test_use_platform_unsupported(_mock):
     assert _call() is False

--- a/tests/v1/attention/test_flashinfer_dcp_spec_reorder.py
+++ b/tests/v1/attention/test_flashinfer_dcp_spec_reorder.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FlashInfer GQA builder: reorder threshold under DCP with spec decode."""
+
+import pytest
+import torch
+
+from tests.v1.attention.utils import create_vllm_config
+from vllm.config import SpeculativeConfig
+from vllm.platforms import current_platform
+from vllm.v1.attention.backends import flashinfer as flashinfer_backend
+from vllm.v1.attention.backends.flashinfer import (
+    FlashInferDecodeKernel,
+    FlashInferMetadataBuilder,
+)
+from vllm.v1.attention.backends.utils import PerLayerParameters
+from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+if not current_platform.is_cuda():
+    pytest.skip("FlashInfer backend requires a CUDA platform.", allow_module_level=True)
+
+
+def test_flashinfer_gqa_dcp_spec_decode_clamps_reorder_threshold(monkeypatch):
+    """trtllm-gen decode receives no cp_rank/global-seq-len information, so its
+    end-aligned causal mask is wrong for q_len > 1 over the DCP-interleaved
+    local KV shard. The builder must keep reorder_batch_threshold at 1 under
+    DCP so spec queries take the (DCP-aware) prefill path instead.
+    """
+    vllm_config = create_vllm_config(max_model_len=1024)
+    vllm_config.parallel_config.decode_context_parallel_size = 2
+    vllm_config.speculative_config = SpeculativeConfig(
+        method="ngram", num_speculative_tokens=3
+    )
+
+    monkeypatch.setattr(
+        flashinfer_backend, "can_use_trtllm_attention", lambda *args, **kwargs: True
+    )
+    monkeypatch.setattr(
+        FlashInferMetadataBuilder,
+        "_get_flashinfer_trtllm_api_decode_kernel",
+        staticmethod(lambda: FlashInferDecodeKernel.TRTLLM_GEN),
+    )
+    monkeypatch.setattr(
+        flashinfer_backend,
+        "get_per_layer_parameters",
+        lambda *args, **kwargs: {
+            "layer.0": PerLayerParameters(
+                window_left=-1, logits_soft_cap=None, sm_scale=0.1, has_sinks=False
+            )
+        },
+    )
+
+    kv_cache_spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=vllm_config.model_config.get_num_kv_heads(
+            vllm_config.parallel_config
+        ),
+        head_size=vllm_config.model_config.get_head_size(),
+        dtype=vllm_config.model_config.dtype,
+    )
+    builder = FlashInferMetadataBuilder(
+        kv_cache_spec,
+        ["layer.0"],
+        vllm_config,
+        torch.device("cpu"),
+    )
+
+    # Guard against passing vacuously with the kernel disabled.
+    assert (
+        builder.flashinfer_trtllm_api_decode_kernel == FlashInferDecodeKernel.TRTLLM_GEN
+    )
+    assert builder.reorder_batch_threshold == 1

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -439,6 +439,16 @@ def use_trtllm_attention(
     if force_use_trtllm is not None and not force_use_trtllm:
         return False
 
+    # TRTLLM prefill attends only the DCP-local KV shard and has no
+    # cross-rank LSE combine, so it cannot be used with DCP; fall back to
+    # FlashInfer's DCP prefill path. TRTLLM decode under DCP is selected
+    # separately (all-gathered query heads + LSE combine in forward).
+    if dcp_world_size > 1:
+        logger.warning_once(
+            "TRTLLM prefill does not support DCP, reverting to FlashInfer"
+        )
+        return False
+
     # The platform is not supported
     if not supports_trtllm_attention(is_prefill=is_prefill):
         if force_use_trtllm:

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1122,23 +1122,6 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             has_sinks=self.has_sinks,
             has_spec=uses_spec_reorder,
         )
-        if (
-            causal
-            and self.use_dcp
-            and not prefill_use_trtllm
-            and self.flashinfer_trtllm_api_decode_kernel
-            == FlashInferDecodeKernel.TRTLLM_GEN
-            and can_use_trtllm_attention(
-                self.num_qo_heads,
-                self.num_kv_heads,
-                is_prefill=True,
-            )
-        ):
-            logger.info_once(
-                "Using TRTLLM prefill attention with DCP because trtllm-gen "
-                "attention is available."
-            )
-            prefill_use_trtllm = True
         decode_with_flashinfer_trtllm_api = causal and self.use_trtllm_decode_attention
 
         if not causal and self.use_dcp:
@@ -1322,6 +1305,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             assert qo_indptr_prefill_cpu.shape[0] == num_prefills + 1
 
             if prefill_use_trtllm:
+                # TRTLLM prefill has no cross-rank combine for DCP-sharded KV;
+                # use_trtllm_attention never selects it when DCP is enabled.
+                assert not self.use_dcp
                 # Create GPU versions
                 qo_indptr_prefill_gpu = (
                     qo_indptr[prefill_start:] - qo_indptr[prefill_start]
@@ -1330,13 +1316,6 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 # This is the cumulative sum of the number of KV cache
                 # blocks per prefill request.
                 prefill_seq_lens = seq_lens[prefill_start:]
-                if self.use_dcp:
-                    prefill_seq_lens = get_dcp_local_seq_lens(
-                        prefill_seq_lens,
-                        self.dcp_world_size,
-                        self.dcp_rank,
-                        self.dcp_kv_cache_interleave_size,
-                    )
                 num_blocks_per_req = (prefill_seq_lens + page_size - 1) // page_size
                 paged_kv_indptr_prefill_gpu = self.paged_kv_indptr.gpu[
                     prefill_start : num_reqs + 1

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -752,7 +752,14 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self._init_reorder_batch_threshold(
             1,
             supports_spec_as_decode=supports_spec_as_decode,
-            supports_dcp_with_varlen=supports_spec_as_decode,
+            # trtllm-gen decode receives no cp_rank/global-seq-len information,
+            # so its end-aligned causal mask is wrong for q_len > 1 over the
+            # DCP-interleaved local KV shard (spec token i misses up to
+            # (dcp_world_size - 1) * (q_len - 1 - i) KV entries, including its
+            # own). Keep the threshold at 1 under DCP so spec queries take the
+            # DCP-aware prefill path, until the kernel is CP-aware (compare
+            # flash_attn_varlen_func's cp_world_size/cp_rank/cp_tot_seqused_k).
+            supports_dcp_with_varlen=False,
         )
 
         self._cascade_wrapper = None  # Wrapper for cascade attention


### PR DESCRIPTION
## Purpose

Two correctness gates for vllm-project/vllm#48180 (this PR targets `pm/tokenspeed-mla-dcp-eagle` so it merges into that PR, per the review discussion there). Neither touches the Tokenspeed MLA path — DCP + Eagle on MLA models (the PR's headline) is unaffected.

**1. Keep native FlashInfer DCP prefill (don't route DCP prefill to TRTLLM).**
`trtllm_batch_context_with_kv_cache` is a single causal kernel with no cross-rank LSE combine, so under DCP each rank attends only its local interleaved KV shard (~1/W of context and of the new tokens' own KV) — compare `BatchDCPPrefillWrapper`, which exists precisely to do head-gather → non-causal local attention → LSE combine → new-token merge. This commit restores the DCP guard in `use_trtllm_attention` (which also un-breaks the existing `test_use_dcp_fallback`) and removes the force-TRTLLM-prefill block.

**2. Don't claim DCP varlen support for trtllm-gen decode.**
`trtllm_batch_decode_with_kv_cache` receives no `cp_rank`/global-seq-len (its `mask` param is documented XQA-only), so for q_len > 1 its end-aligned diagonal causal mask is wrong over the DCP-interleaved local KV: spec token *i* silently misses up to `(W−1)(q_len−1−i)` entries, including its own KV on the owner rank. This mirrors the `flashinfer_mla` revert already made in the parent PR, and the `flashattn_mla` precedent (CP-aware kernel args + interleave gate). Reorder threshold clamps to 1 under DCP, so spec queries take the DCP-aware prefill path; **single-token trtllm-gen DCP decode (all-gathered heads + LSE combine) stays enabled**, and MTP under DCP keeps working end to end.

**Re-enable roadmap** (fix-forward, not blocked by this change):
- Prefill: the trtllm context kernel already exposes `causal=False` + `return_lse`, so a trtllm-flavored DCP prefill wrapper (gather heads → non-causal local run → `cp_lse_ag_out_rs` → new-token merge) is buildable with today's flashinfer API.
- Varlen decode: needs flashinfer to extend spec-mask support to trtllm-gen (the correct mask is rank-dependent and non-diagonal: `bit(i, j) = [pos(local entry) ≤ P_i]`, confined to the last q_len local entries) or to add CP-native args like FA3's `cp_world_size`/`cp_rank`/`cp_tot_seqused_k`.

## Why this is not duplicating an existing PR

It targets the open PR branch itself; no other open PR addresses these paths (checked `gh pr list --search`).

## Test Plan

```bash
pytest tests/kernels/attention/test_use_trtllm_attention.py \
       tests/v1/attention/test_flashinfer_dcp_spec_reorder.py -q
```

## Test Result

On `pm/tokenspeed-mla-dcp-eagle` (2a0a363, before this branch):
- `test_use_dcp_fallback` **FAILS** (pre-existing test; `use_trtllm_attention(dcp_world_size=2)` returns `True`)
- new `test_flashinfer_gqa_dcp_spec_decode_clamps_reorder_threshold` **FAILS** (`assert 4 == 1`; the TRTLLM_GEN-kernel guard assertion passes, so the failure is not vacuous)

With this branch: **31 passed** (28 pre-existing + 3 new: two prefill-guard tests, one builder clamp test). `ruff check` / `ruff format` clean; pre-commit hooks (incl. mypy) pass.

## AI assistance disclosure

Developed with Claude Code assistance (analysis, patch, and tests); the submitter has reviewed the changes and test results. Commits carry `Co-authored-by: Claude`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
